### PR TITLE
Corrigido botão de Buscar empresa

### DIFF
--- a/agendacompartilhada/pages/api/companies/searchByName/[name].ts
+++ b/agendacompartilhada/pages/api/companies/searchByName/[name].ts
@@ -5,8 +5,11 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const { nameSlug } = req.query;
-  const name = nameSlug?.at(0);
+  const { name } = req.query;
+  if (typeof name !== "string") {
+    return res.status(400).json("invalid name");
+  }
+
   const prisma = new PrismaClient();
   await prisma.$connect();
   switch (req.method) {

--- a/agendacompartilhada/pages/index.tsx
+++ b/agendacompartilhada/pages/index.tsx
@@ -37,6 +37,11 @@ const Home: NextPage = () => {
   async function handleSearchCompany(event: any) {
     event.preventDefault();
 
+    if (searchValue == "") {
+      setErrorMessage(["Digite o nome da empresa no campo acima"]);
+      return;
+    }
+
     try {
       const url = "api/companies/searchByName/" + searchValue;
       const response = await fetch(url, {


### PR DESCRIPTION
A rota não estava filtrando o nome das empresas, e quando se apertava o botão de busca com o campo vazio, um erro era gerado.