### PR TITLE
Apenas mostre profissionais livres

### DIFF
--- a/agendacompartilhada/pages/empresas/[id].tsx
+++ b/agendacompartilhada/pages/empresas/[id].tsx
@@ -22,8 +22,13 @@ require("dayjs/locale/pt");
 import Modal from "react-bootstrap/Modal";
 import { Calendar, Company, Contribuitor, ScheduleTime } from "@prisma/client";
 
-interface DateToTimeList {
-  [date: string]: string[];
+interface DateToIntervals {
+  [date: string]: Interval[];
+}
+
+interface Interval {
+  time: string;
+  freeContribuitors: Contribuitor[];
 }
 
 const CompanyPage: NextPage = () => {
@@ -47,7 +52,7 @@ const CompanyPage: NextPage = () => {
   const [showModalScheduleTime, setShowModalScheduleTime] =
     React.useState(false);
   const [selectedScheduleTime, setSelectedScheduleTime] =
-    React.useState<string>("");
+    React.useState<Interval | null>(null);
   const [selectedScheduleDay, setSelectedScheduleDay] =
     React.useState<string>("");
   const [selectedContributor, setSelectedContributor] =
@@ -56,7 +61,7 @@ const CompanyPage: NextPage = () => {
   const [clientPhone, setClientPhone] = React.useState<string>("");
   const [clientName, setClientName] = React.useState<string>("");
   const [schedulesGroupByDay, setSchedulesGroupByDay] =
-    React.useState<DateToTimeList>({});
+    React.useState<DateToIntervals>({});
 
   const handleCloseModal = () => {
     setShowModalScheduleTime(false);
@@ -66,7 +71,7 @@ const CompanyPage: NextPage = () => {
 
   const handleCloseModaAfterCreated = () => {
     setShowModalScheduleTime(false);
-    setSelectedScheduleTime("");
+    setSelectedScheduleTime(null);
     setSelectedScheduleDay("");
     setSelectedContributor("");
     setClientEmail("");
@@ -76,7 +81,7 @@ const CompanyPage: NextPage = () => {
     setErrorMessage([""]);
   };
 
-  const handleShowModalScheduleTime = (sheduleTime: string, day: string) => {
+  const handleShowModalScheduleTime = (sheduleTime: Interval, day: string) => {
     setShowModalScheduleTime(true);
     setSelectedScheduleTime(sheduleTime);
     setSelectedScheduleDay(day);
@@ -108,6 +113,11 @@ const CompanyPage: NextPage = () => {
 
     if (calendar === null) {
       showError("Erro Interno: calendário não existe");
+      return;
+    }
+
+    if (selectedScheduleTime === null) {
+      showError("Erro Interno: selectedScheduleTime não existe");
       return;
     }
 
@@ -175,7 +185,7 @@ const CompanyPage: NextPage = () => {
         contributorId: contributorId,
         scheduleTime: {
           date: dayjs(selectedScheduleDay).format("YYYY-MM-DD"),
-          time: selectedScheduleTime,
+          time: selectedScheduleTime.time,
           duration: calendar.intervalTime,
         },
       };
@@ -204,6 +214,7 @@ const CompanyPage: NextPage = () => {
         }
       } catch (error) {
         console.log(error);
+        showError(`Erro Interno: ${error}`);
       }
     }
   };
@@ -308,25 +319,30 @@ const CompanyPage: NextPage = () => {
         }
       }
 
-      let weekIntervalTimesList: DateToTimeList = {};
+      let weekIntervalTimesList: DateToIntervals = {};
 
       for (let index = 0; index < 5; index++) {
         weekIntervalTimesList[date.add(index, "day").format("DD-MM-YYYY")] =
-          intervalTimesList;
+          intervalTimesList.map((x) => {
+            return { time: x, freeContribuitors: [...contributors] };
+          });
       }
 
+      // remove os contribuidores ocupados da lista freeContribuitors.
       scheduleTimes.map((scheduleTime) => {
         const dateAsKey = dayjs(new Date(scheduleTime.date))
           .add(1, "day")
           .format("DD-MM-YYYY"); //necessario adicionar 1 dia
 
-        if (weekIntervalTimesList[dateAsKey].includes(scheduleTime.time)) {
-          weekIntervalTimesList[dateAsKey] = weekIntervalTimesList[
-            dateAsKey
-          ].filter(function (item: string) {
-            //preciso verificar se existe prestador disponível
-            return item != scheduleTime.time;
-          });
+        const interval = weekIntervalTimesList[dateAsKey].find(
+          (x) => x.time == scheduleTime.time
+        );
+
+        if (interval) {
+          const index = interval.freeContribuitors.findIndex(
+            (x) => x.id == scheduleTime.contribuitorId
+          );
+          if (index >= 0) interval.freeContribuitors.splice(index, 1);
         }
       });
 
@@ -378,7 +394,7 @@ const CompanyPage: NextPage = () => {
         }
       });
     }
-  }, [path, company, date, calendar, intervalsAreUpdated]);
+  }, [path, company, contributors, date, calendar, intervalsAreUpdated]);
 
   return (
     <div>
@@ -460,7 +476,7 @@ const CompanyPage: NextPage = () => {
                       <Form.Control
                         autoFocus
                         className="bg-white"
-                        value={selectedScheduleTime}
+                        value={selectedScheduleTime?.time ?? ""}
                         disabled
                       />
                     </Form.Group>
@@ -490,11 +506,13 @@ const CompanyPage: NextPage = () => {
                         }}
                       >
                         <option></option>
-                        {contributors.map((contribuitor, index) => (
-                          <option className={styles.option} key={index}>
-                            {contribuitor.name}
-                          </option>
-                        ))}
+                        {selectedScheduleTime?.freeContribuitors.map(
+                          (contribuitor, index) => (
+                            <option className={styles.option} key={index}>
+                              {contribuitor.name}
+                            </option>
+                          )
+                        )}
                       </Form.Select>
                     </Form.Group>
                     <Form.Group
@@ -618,19 +636,22 @@ const CompanyPage: NextPage = () => {
                           ) : (
                             schedulesGroupByDay[
                               date.add(num, "day").format("DD-MM-YYYY")
-                            ].map((timeString: string, index: any) => (
+                            ].map((interval: Interval, index: any) => (
                               <Card.Text key={index} className="my-3">
                                 <Button
                                   variant="outline-success"
                                   className="text-center"
+                                  disabled={
+                                    interval.freeContribuitors.length == 0
+                                  }
                                   onClick={() => {
                                     handleShowModalScheduleTime(
-                                      timeString,
+                                      interval,
                                       date.add(num, "day").format("YYYY-MM-DD")
                                     );
                                   }}
                                 >
-                                  {timeString}
+                                  {`${interval.time} +${interval.freeContribuitors.length}`}
                                 </Button>
                               </Card.Text>
                             ))

--- a/agendacompartilhada/pages/empresas/[id].tsx
+++ b/agendacompartilhada/pages/empresas/[id].tsx
@@ -22,6 +22,10 @@ require("dayjs/locale/pt");
 import Modal from "react-bootstrap/Modal";
 import { Calendar, Company, Contribuitor, ScheduleTime } from "@prisma/client";
 
+interface DateToTimeList {
+  [date: string]: string[];
+}
+
 const CompanyPage: NextPage = () => {
   const [errorMessage, setErrorMessage] = React.useState<string[]>([""]);
   const [viewIsReady, setViewIsReady] = React.useState<boolean>(false);
@@ -51,7 +55,8 @@ const CompanyPage: NextPage = () => {
   const [clientEmail, setClientEmail] = React.useState<string>("");
   const [clientPhone, setClientPhone] = React.useState<string>("");
   const [clientName, setClientName] = React.useState<string>("");
-  const [schedulesGroupByDay, setSchedulesGroupByDay] = React.useState<any>({});
+  const [schedulesGroupByDay, setSchedulesGroupByDay] =
+    React.useState<DateToTimeList>({});
 
   const handleCloseModal = () => {
     setShowModalScheduleTime(false);
@@ -265,7 +270,10 @@ const CompanyPage: NextPage = () => {
   }, [id, path]);
 
   React.useEffect(() => {
-    function updateIntervals(calendar: Calendar | null, scheduleTimes: any[]) {
+    function updateIntervals(
+      calendar: Calendar | null,
+      scheduleTimes: ScheduleTime[]
+    ) {
       let intervalTimesList: string[] = [];
       if (calendar) {
         const [startHour, startMinute] = calendar.startTime.split(":");
@@ -300,7 +308,7 @@ const CompanyPage: NextPage = () => {
         }
       }
 
-      let weekIntervalTimesList: any = {};
+      let weekIntervalTimesList: DateToTimeList = {};
 
       for (let index = 0; index < 5; index++) {
         weekIntervalTimesList[date.add(index, "day").format("DD-MM-YYYY")] =
@@ -315,7 +323,7 @@ const CompanyPage: NextPage = () => {
         if (weekIntervalTimesList[dateAsKey].includes(scheduleTime.time)) {
           weekIntervalTimesList[dateAsKey] = weekIntervalTimesList[
             dateAsKey
-          ].filter(function (item: any) {
+          ].filter(function (item: string) {
             //preciso verificar se existe prestador disponível
             return item != scheduleTime.time;
           });
@@ -330,8 +338,8 @@ const CompanyPage: NextPage = () => {
       initialDate: String,
       endDate: String,
       id: Number
-    ) {
-      let scheduleTimesList = [];
+    ): Promise<ScheduleTime[]> {
+      let scheduleTimesList: ScheduleTime[] = [];
       try {
         const data = {
           companyId: id,
@@ -347,12 +355,11 @@ const CompanyPage: NextPage = () => {
           body: JSON.stringify(data),
         });
         if (response.status == 200) {
-          const { scheduleTimes } = await response.json();
+          const scheduleTimes: ScheduleTime[] = (await response.json())
+            .scheduleTimes;
           setSearchedScheduleTimes(true);
           scheduleTimesList = scheduleTimes;
         }
-      } catch (error) {
-        throw error;
       } finally {
         return scheduleTimesList;
       }


### PR DESCRIPTION
Agora na janela de agendar um horário só estará listado os profissionais livres naquele horário.

Também no botões de horário mostra a contagem de profissionais livres naquele horário, e os botões de contagem 0 são desabilitados.

Talvez seja melhor esconder os botões em vez de desabilitados, e talvez exista uma forma melhor de mostrar a contagem, mas ainda podemos decidir isso depois.